### PR TITLE
Bump dependencies nan and jsverify

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "lib.js",
   "dependencies": {
-    "nan": "2.6"
+    "nan": "2.10"
   },
   "devDependencies": {
     "jsverify": "0.8",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "nan": "2.10"
   },
   "devDependencies": {
-    "jsverify": "0.8",
+    "jsverify": "^0.8.3",
     "shuffle-array": "1.0"
   },
   "scripts": {


### PR DESCRIPTION
Currently, compiling `sss-node` fails on some fresh installations. Updating `nan` solves this issue.